### PR TITLE
Update Travis CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,70 @@
+sudo: false
 language: rust
+addons:
+  apt:
+    packages:
+      - libsdl1.2-dev
+      # necessary for `travis-cargo coveralls --no-sudo`
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - binutils-dev # optional: only required for the --verify flag of coveralls
+# run builds for all the trains (and more)
+rust:
+  - nightly
+  - beta
+  # check that it compiles on the latest stable compiler
+  - stable
+  # and the first stable one (this should be bumped as the minimum Rust version
+  # required changes)
+  # currently the project only compiles on the latest stable, so this is
+  # commented out for now.
+  #- 1.9.0
 os:
-    - linux
-    - osx
+  - linux
+  - osx
+cache:
+  directories:
+    - $HOME/.cargo
+before_install:
+  - |
+      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 install:
-    - sudo apt-get update
-    - sudo apt-get install gcc g++ make upx electric-fence libsdl1.2-dev mercurial
+  - |
+      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl; fi
+before_script:
+  # load travis-cargo
+  - |
+      pip install 'travis-cargo<0.2' --user &&
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$HOME/.local/bin/:$PATH; fi
+      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$HOME/Library/Python/2.7/bin:$PATH; fi
+# the main build
 script:
-    - cargo build -v
+  - |
+      travis-cargo build &&
+      travis-cargo test &&
+      travis-cargo bench &&
+      travis-cargo --only stable doc
+after_success:
+  # upload the documentation from the build with stable (automatically only
+  # actually runs from the master branch, not individual PRs)
+  - travis-cargo --only stable doc-upload
+  # measure code coverage and upload to coveralls.io (the verify argument
+  # mitigates kcov crashes due to malformed debuginfo, at the cost of some
+  # speed. <https://github.com/huonw/travis-cargo/issues/12>)
+  - travis-cargo coveralls --no-sudo --verify
+env:
+  global:
+    # override the default '--features unstable' used for the nightly branch
+    - TRAVIS_CARGO_NIGHTLY_FEATURE="nightly-testing"
+    # encrypted Github token for doc upload
+    - secure: kQKcc0WiucWrIGC+t7ASfoKGs9nGdll94egke0pFTBIsh8e4dPgUK6hGBGfJE32FJS6VB3lyoAqNQQDCLnYwxsq2IOL4T1F65K4bDS9IvR1HXduvXj+z5NHU5VAerD7Czc0q+9Na2qEZQPEW9u6+eX4xX5E0c4p0eUoGMNQaXYg5bzRJ68uC8d8WAj2KOXx8G7Seak5xBmvP5vOBWJjCMv7leVoWwfP9OI+MizzDhzeYL5ux49STsP67/jrL37Otdly6Cvv9NsamCyoZ3McQq436pViUl2XJ3/ctvc17JNm+FdIdjKaZL1fMje2xyvYK9weyKjRiMmkDETWvsCFqL/Y37Oe80kh+KFKYSxgl6Q5IaiO35hUjBRDVmi/zuZGD8cI3GVE/qFj2yN+/srBzORgpJgofPaMurI6udQoCNiNqvAh9PJ0KpKvkCGNTUUXDYcv9k4BLIpudY0HqTNM341MkOD98NC99TsA9eJwWyEre3rLqkVztTzkGa7VM1MT/6bgVi+BdPfO3AEy5xs1Y4ut2Qzl54rFK2AGRFDdJ4CvyQykBg/EDxpkI7w0VdqUyOrSWNQFqv4xTwXPd91r2OhUUm76gsN50gwZTxJvae/aIGRdd3GyNQ149HHzNB5HLpct5KsGlCcwQ7QcbKFQkpCLC0R3sgeKGUaRbqZjwN5M=
+branches:
+  only:
+    - master
+    - auto
+notifications:
+  email: false
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/README.md
+++ b/README.md
@@ -1,22 +1,74 @@
-# tcod_window [![Build Status](https://travis-ci.org/indiv0/tcod_window.svg?branch=master)](https://travis-ci.org/indiv0/tcod_window)
+# tcod_window
 
-A TCOD back-end for the Piston game engine
+<table>
+    <tr>
+        <td><strong>Linux / OS X</strong></td>
+        <td><a href="https://travis-ci.org/indiv0/tcod_window" title="Travis Build Status"><img src="https://travis-ci.org/indiv0/tcod_window.svg?branch=master" alt="travis-badge"></img></a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+            <a href="https://indiv0.github.io/tcod_window/tcod_window" title="API Docs"><img src="https://img.shields.io/badge/API-docs-blue.svg" alt="api-docs-badge"></img></a>
+            <a href="https://crates.io/crates/tcod_window" title="Crates.io"><img src="https://img.shields.io/crates/v/tcod_window.svg" alt="crates-io"></img></a>
+            <a href="#License" title="License: MIT/Apache-2.0"><img src="https://img.shields.io/crates/l/tcod_window.svg" alt="license-badge"></img></a>
+            <a href="https://coveralls.io/github/indiv0/tcod_window?branch=master" title="Coverage Status"><img src="https://coveralls.io/repos/github/indiv0/tcod_window/badge.svg?branch=master" alt="coveralls-badge"></img></a>
+            <a href="http://clippy.bashy.io/github/indiv0/tcod_window/master/log" title="Clippy Linting Result"><img src="http://clippy.bashy.io/github/indiv0/tcod_window/master/badge.svg" alt="clippy-lint-badge"></img></a>
+        </td>
+    </tr>
+</table>
 
-Maintainers: @indiv0
+A TCOD back-end for the Piston game engine.
 
-# Installation
 
-To use this as a dependency, add the following code to your Cargo.toml
-file:
+# Table of Contents
+
+* [Usage](#usage)
+* [Contributing](#contributing)
+* [Credits](#credits)
+* [License](#license)
+
+## Usage
+
+Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tcod_window = "0.1.0"
+tcod_window = "0.2"
 ```
 
-## Usage
+And in your `lib.rs` or `main.rs`:
+
+```rust
+extern crate tcod_window;
+```
+
+See the [API docs][api-docs] for information on using the crate in your library.
 
 For usage examples, please the see the [examples][examples] directory of the
 project.
 
+## Contributing
+
+Contributions are always welcome!
+If you have an idea for something to add (code, documentation, tests, examples,
+etc.) feel free to give it a shot.
+
+Please read [CONTRIBUTING.md][contributing] before you start contributing.
+
+## Credits
+
+The list of contributors to this project can be found at
+[CONTRIBUTORS.md][contributors].
+
+## License
+
+`tcod_window` is distributed under the terms of both the MIT license and the
+Apache License (Version 2.0).
+
+See [LICENSE-APACHE][license-apache], and [LICENSE-MIT][license-mit] for details.
+
+[api-docs]: https://indiv0.github.io/tcod_window/tcod_window
+[contributing]: https://github.com/indiv0/tcod_window/blob/master/CONTRIBUTING.md "Contribution Guide"
+[contributors]: https://github.com/indiv0/tcod_window/blob/master/CONTRIBUTORS.md "List of Contributors"
 [examples]: https://github.com/indiv0/tcod_window/tree/master/examples "tcod_window - Examples"
+[license-apache]: https://github.com/indiv0/tcod_window/blob/master/LICENSE-APACHE "Apache-2.0 License"
+[license-mit]: https://github.com/indiv0/tcod_window/blob/master/LICENSE-MIT "MIT License"


### PR DESCRIPTION
Enable benchmarking, testing, code coverage, and doc upload in the Travis CI
configuration.

Fix Travis CI builds on OS X.

Closes #7.
