### PR TITLE
Update Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,19 @@ after_success:
   # upload the documentation from the build with stable (automatically only
   # actually runs from the master branch, not individual PRs)
   - travis-cargo --only stable doc-upload
+  # copy the `libtcod.so` shared library to the build directory so that `kcov`
+  # can run correctly.
+  - cp $TRAVIS_BUILD_DIR/target/debug/build/tcod-sys-*/out/libtcod.so $TRAVIS_BUILD_DIR/
   # measure code coverage and upload to coveralls.io (the verify argument
   # mitigates kcov crashes due to malformed debuginfo, at the cost of some
   # speed. <https://github.com/huonw/travis-cargo/issues/12>)
   - travis-cargo coveralls --no-sudo --verify
 env:
   global:
+    - RUST_BACKTRACE=1
     # override the default '--features unstable' used for the nightly branch
     - TRAVIS_CARGO_NIGHTLY_FEATURE="nightly-testing"
+    - RUSTFLAGS="-C link-dead-code"
     # encrypted Github token for doc upload
     - secure: kQKcc0WiucWrIGC+t7ASfoKGs9nGdll94egke0pFTBIsh8e4dPgUK6hGBGfJE32FJS6VB3lyoAqNQQDCLnYwxsq2IOL4T1F65K4bDS9IvR1HXduvXj+z5NHU5VAerD7Czc0q+9Na2qEZQPEW9u6+eX4xX5E0c4p0eUoGMNQaXYg5bzRJ68uC8d8WAj2KOXx8G7Seak5xBmvP5vOBWJjCMv7leVoWwfP9OI+MizzDhzeYL5ux49STsP67/jrL37Otdly6Cvv9NsamCyoZ3McQq436pViUl2XJ3/ctvc17JNm+FdIdjKaZL1fMje2xyvYK9weyKjRiMmkDETWvsCFqL/Y37Oe80kh+KFKYSxgl6Q5IaiO35hUjBRDVmi/zuZGD8cI3GVE/qFj2yN+/srBzORgpJgofPaMurI6udQoCNiNqvAh9PJ0KpKvkCGNTUUXDYcv9k4BLIpudY0HqTNM341MkOD98NC99TsA9eJwWyEre3rLqkVztTzkGa7VM1MT/6bgVi+BdPfO3AEy5xs1Y4ut2Qzl54rFK2AGRFDdJ4CvyQykBg/EDxpkI7w0VdqUyOrSWNQFqv4xTwXPd91r2OhUUm76gsN50gwZTxJvae/aIGRdd3GyNQ149HHzNB5HLpct5KsGlCcwQ7QcbKFQkpCLC0R3sgeKGUaRbqZjwN5M=
 branches:


### PR DESCRIPTION
Add `RUST_BACKTRACE=1` env var to Travis CI env.
Add `RUSTFLAGS` env var to Travis CI env to improve `kcov` code coverage.
Add `LD_LIBRARY_PATH` env var to Travis CI env to ensure that kcov can link to
`libtcod.so`.
