### PR TITLE
Add Integration Test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,9 +470,9 @@ mod tests {
             )
         );
 
-        assert_eq!(window.should_close(), false);
+        assert!(!window.should_close());
         window.set_should_close(true);
-        assert_eq!(window.should_close(), true);
+        assert!(window.should_close());
 
         window.swap_buffers();
 
@@ -505,9 +505,9 @@ mod tests {
         window.set_title("some other name".to_owned());
         assert_eq!(window.get_title(), "some other name".to_owned());
 
-        assert_eq!(window.get_exit_on_esc(), false);
+        assert!(!window.get_exit_on_esc());
         window.set_exit_on_esc(true);
-        assert_eq!(window.get_exit_on_esc(), true);
+        assert!(window.get_exit_on_esc());
 
         window.set_capture_cursor(true);
     }

--- a/tests/tcod_window.rs
+++ b/tests/tcod_window.rs
@@ -1,0 +1,26 @@
+extern crate piston;
+extern crate tcod;
+extern crate tcod_window;
+
+use piston::event_loop::Events;
+use piston::window::{Size, WindowSettings};
+use tcod::console::Console;
+use tcod_window::TcodWindow;
+
+#[test]
+fn test_tcod_window() {
+    let mut window = TcodWindow::new(
+        WindowSettings::new(
+           "My Application".to_owned(),
+            Size {
+                width: 100,
+                height: 100,
+            }
+        )
+    );
+    let mut events = window.events();
+
+    window.window.borrow_mut().print(0, 0, "Test print!");
+
+    assert!(events.next(&mut window).is_some());
+}


### PR DESCRIPTION
Add very rudimentary integration test for `tcod_window`.

Fix improper `assert_eq!` statements in unit tests.

Closes #9.
